### PR TITLE
Release: Add inital release Readme

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,1 @@
+## Intel Data Center GPU Driver Container Images For OpenShift Release


### PR DESCRIPTION
Release directory is used to maintain the release information for Intel Data Center GPU Driver Container Images for OpenShift