### PR TITLE
docker: Commenting out the CSE driver

### DIFF
--- a/docker/intel-dgpu-driver.Dockerfile
+++ b/docker/intel-dgpu-driver.Dockerfile
@@ -6,8 +6,8 @@ FROM ${DTK_AUTO} as builder
 
 WORKDIR /build/
 
-# Building cse(MEI) driver
-RUN git clone -b 23WW06.5_555_MAIN --single-branch https://github.com/intel-gpu/intel-gpu-cse-backports.git && cd intel-gpu-cse-backports && export OS_TYPE=rhel_8 && export OS_VERSION="8.6" && make modules && make modules_install
+# Building cse(MEI) driver. We are disabling this for now as its not currently used.
+# RUN git clone -b 23WW06.5_555_MAIN --single-branch https://github.com/intel-gpu/intel-gpu-cse-backports.git && cd intel-gpu-cse-backports && export OS_TYPE=rhel_8 && export OS_VERSION="8.6" && make modules && make modules_install
 
 # Building pmt(VSEC) driver
 RUN git clone -b 23WW06.5_555_MAIN --single-branch https://github.com/intel-gpu/intel-gpu-pmt-backports.git && cd intel-gpu-pmt-backports && export OS_TYPE=rhel_8 && export OS_VERSION="8.6" && make modules && make modules_install


### PR DESCRIPTION
Currently, the CSE driver is not used, so comment it. This was tested on Openshift version 4.12.6 which has kernel version 4.18.0-372.46.1.el8_6.x86_64

Signed-off-by: Manish Regmi <manish.regmi@intel.com>