### PR TITLE
docker: Improve driver container image size

### DIFF
--- a/docker/intel-dgpu-driver.Dockerfile
+++ b/docker/intel-dgpu-driver.Dockerfile
@@ -15,6 +15,7 @@ FROM ${DTK_AUTO} as builder
 ARG PMT_RELEASE
 ARG I915_RELEASE
 ARG FIRMWARE_RELEASE
+ARG KERNEL_FULL_VERSION
 
 WORKDIR /build
 
@@ -37,10 +38,17 @@ RUN git clone -b ${I915_RELEASE} --single-branch https://github.com/intel-gpu/in
     && cp defconfigs/drm .config \
     && make olddefconfig && make -j $(nproc) && make modules_install
 
+# Create /build/modules directory with all *.ko and *.ko.xz files
+RUN mkdir -p /build/modules \
+    && find /lib/modules/${KERNEL_FULL_VERSION}/ \
+    -name "*.ko" -o -name "*.ko.xz" -o -name "modules.order" -o -name "modules.builtin" -type f \
+    | xargs -I {} install -D {} /build/modules/
+
 # Firmware
 RUN git clone -b ${FIRMWARE_RELEASE} --single-branch https://github.com/intel-gpu/intel-gpu-firmware.git \
     && install -D /build/intel-gpu-firmware/COPYRIGHT /licenses/firmware/COPYRIGHT \
-    && install -D /build/intel-gpu-firmware/COPYRIGHT /build/intel-gpu-firmware/firmware/license/COPYRIGHT
+    && install -D /build/intel-gpu-firmware/COPYRIGHT /build/firmware/license/COPYRIGHT \
+    && install -D /build/intel-gpu-firmware/firmware/dg2* /build/firmware/
 
 FROM registry.redhat.io/ubi8/ubi-minimal:latest
 ARG DRIVER_VERSION
@@ -63,7 +71,7 @@ RUN microdnf update -y && rm -rf /var/cache/yum
 RUN microdnf -y install kmod findutils && microdnf clean all
 COPY --from=builder /licenses/ /licenses/
 COPY --from=builder /etc/driver-toolkit-release.json /etc/
-COPY --from=builder /lib/modules/${KERNEL_FULL_VERSION}/ /opt/lib/modules/${KERNEL_FULL_VERSION}/
-COPY --from=builder /build/intel-gpu-firmware/firmware/ /firmware/i915/
+COPY --from=builder /build/modules/ /opt/lib/modules/${KERNEL_FULL_VERSION}/
+COPY --from=builder /build/firmware/ /firmware/i915/
 
 RUN depmod -b /opt ${KERNEL_FULL_VERSION}


### PR DESCRIPTION
Copy only the necessary ko files and firmware binaries to minimize final driver container image size. See #33 for more details.
Signed-off-by: Hersh Pathak hersh.pathak@intel.com