### PR TITLE
Makefile: Added makefile to simplify Terrascan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+terrascan:
+	@ls */*.Dockerfile | while read f ; \
+	do \
+		echo "==== $$f ====" ; \
+		terrascan scan -v --show-passed -d $$(dirname $$f) -i docker --severity high \
+		|| exit $$? ; \
+	done > drivers-terrascan-result.txt
+
+clean-terrascan:
+	rm -rf drivers-terrascan-result.txt


### PR DESCRIPTION
Added Terrascan for scanning related dockerfiles in this project. 
Usage:
```
$ make terrascan
```
output:
Scan results stored in the file `drivers-terrascan-result.txt` 

Clean the output file using:
```
$ make clean-terrascan
```
Signed-off-by: chaitanya1731 <chaitanya.kulkarni@intel.com>